### PR TITLE
Configured clang-format to group and sort includes

### DIFF
--- a/config_files/esrlabs_clang_format.cfg
+++ b/config_files/esrlabs_clang_format.cfg
@@ -53,13 +53,21 @@ DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 #FixNamespaceComments: true
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
+  - Regex:           '^(<|")(estd|platform)\/.*'
     Priority:        3
-  - Regex:           '.*'
+
+  - Regex :          '<[[:alnum:].]+>'
+    Priority:        100
+
+  - Regex:           '^".*'
     Priority:        1
+
+  - Regex:           '^<.*'
+    Priority:        2
+
 IncludeIsMainRegex: '$'
 IndentCaseLabels: true
 IndentWidth:     4
@@ -82,7 +90,7 @@ PenaltyExcessCharacter: 100000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    false
+SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements

--- a/config_files/esrlabs_clang_format.cfg
+++ b/config_files/esrlabs_clang_format.cfg
@@ -56,8 +56,11 @@ ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^(<|")(estd|platform)\/.*'
+  - Regex:           '^<(estd|platform)\/.*'
     Priority:        3
+
+  - Regex:           '^<(gtest|gmock)\/.*'
+    Priority:        4
 
   - Regex :          '<[[:alnum:].]+>'
     Priority:        100
@@ -68,7 +71,7 @@ IncludeCategories:
   - Regex:           '^<.*'
     Priority:        2
 
-IncludeIsMainRegex: '$'
+IncludeIsMainRegex: '(_test|Test|Tests)?$'
 IndentCaseLabels: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false


### PR DESCRIPTION
As clang 6 is in broad usage already, it's time to use its features.
This change enables clang-format to automatically apply the rules from
our coding guidelines (this is a quote from docs/General.md):

---
The style used to specify an include shall reflect the locality of the
included header file.

1. All includes which are part of the module the including header file
is part of shall use quotes ""
2. All includes which are not part of the module the including header
(external includes) file is part of shall use angle brackets <>
3. Sort includes alphabetically
4. Put external includes after internal ones
---

I also took the liberty to separate platfrom and estd headers as a
separate group - placing them between all the library headers in <> and
standard library headers.